### PR TITLE
Add antigen compatible plugin description

### DIFF
--- a/gitflow-avh.plugin.zsh
+++ b/gitflow-avh.plugin.zsh
@@ -1,0 +1,23 @@
+# This allows the gitflow-avh commands to be installed in ZSH using antigen.
+# Antigen is a bundle manager. It allows you to enhance the functionality of
+# your zsh session by installing bundles and themes easily.
+
+# Antigen documentation:
+# http://antigen.sharats.me/
+# https://github.com/zsh-users/antigen
+
+# Install gitflow-avh:
+# antigen bundle petervanderdoes/gitflow-avh
+# Bundles installed by antigen are available for use immediately.
+
+# Update gitflow-avh (and all other antigen bundles):
+# antigen update
+
+# The antigen command will download the git repository to a folder and then
+# execute an enabling script (this file). The complete process for loading the
+# code is documented here:
+# https://github.com/zsh-users/antigen#notes-on-writing-plugins
+
+# This specific script just adds the project folder to the PATH. This makes all
+# commands available in git.
+export PATH="${PATH}":`dirname "${0}"`

--- a/gitflow-avh.plugin.zsh
+++ b/gitflow-avh.plugin.zsh
@@ -7,7 +7,7 @@
 # https://github.com/zsh-users/antigen
 
 # Install gitflow-avh:
-# antigen bundle petervanderdoes/gitflow-avh
+# antigen bundle petervanderdoes/gitflow-avh --branch=master
 # Bundles installed by antigen are available for use immediately.
 
 # Update gitflow-avh (and all other antigen bundles):


### PR DESCRIPTION
This adds antigen support for ZSH. See https://github.com/zsh-users/antigen for more details.

This allows a user to start using this library using the command:

```bash
antigen bundle matthewfranglen/gitflow-cjs --branch=develop
```

Which handles downloading the repository and adding the command to your path.

I'm opening this PR as suggested by you in [this comment](https://github.com/petervanderdoes/gitflow-avh/pull/349#issuecomment-1585700189).