### PR TITLE
fig(release finish): remove -v --verbose from --help list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,9 @@
 
 # Changelog
 
+#### 1.12.6-DEV1
+* Fix release finish --help showing -v --verbose flag
+
 #### 1.12.5
 * Cherry-Pick  Speed up "list" command execution #325 from gpongelli/gitflow-avh/tree/speedUpListCmd
 * Updated readme links Thank You [JamesSkemp](https://github.com/JamesSkemp)

--- a/git-flow-release
+++ b/git-flow-release
@@ -555,7 +555,6 @@ Start a new release branch
 h,help!              Show this help
 showcommands!        Show git commands while executing them
 F,[no]fetch          Fetch from $ORIGIN before performing finish
-v,verbose!           Verbose (more) output
 "
 	local base
 


### PR DESCRIPTION
Currently release finish does not support a verbose option. This removes it from the help display.