### PR TITLE
fix(release start): remove -v --verbose from --help

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,9 @@
 
 # Changelog
 
+#### 1.12.6-DEV.1
+* Fix release start --help showing invalid option
+
 #### 1.12.5
 * Cherry-Pick  Speed up "list" command execution #325 from gpongelli/gitflow-avh/tree/speedUpListCmd
 * Updated readme links Thank You [JamesSkemp](https://github.com/JamesSkemp)

--- a/git-flow-release
+++ b/git-flow-release
@@ -555,7 +555,6 @@ Start a new release branch
 h,help!              Show this help
 showcommands!        Show git commands while executing them
 F,[no]fetch          Fetch from $ORIGIN before performing finish
-v,verbose!           Verbose (more) output
 "
 	local base
 


### PR DESCRIPTION
When running release start subcommand with --help the output indicated you could get more "verbose" output with -v --verbose. More verbose output is currently not supported by release start.

This removes the flags from --help for release start.